### PR TITLE
BST traversals and improved delete

### DIFF
--- a/src/bst.erl
+++ b/src/bst.erl
@@ -142,10 +142,26 @@ merge(#tree{left = L1, key = K1, value = V1, right = R1}, #tree{left = L2, key =
   merge(N, R2).
 
 % TODO delete from BST -> filter
-delete(_K, empty) -> empty;
-delete(K, #tree{left = L, key = X, right = R}) when K == X -> merge(L,R);
-delete(K, #tree{left = L, key = X, value = V, right = R}) when K < X -> new(delete(K, L), X, V, R);
-delete(K, #tree{left = L, key = X, value = V, right = R}) when K > X -> new(L, X, V, delete(K, R)).
+
+%% @doc delete entry with key K from BST
+-spec delete(T :: bst(K,V), Key :: K) -> bst(K,V).
+delete(_, empty) -> empty;
+delete(X, #tree{key = X, left = empty, right = R}) -> R;
+delete(X, #tree{key = X, left = L, right = empty}) -> L;
+delete(X, #tree{key = X, left = L, right = R}) ->
+  {{K2, V2}, R2} = delete_min(R),
+  #tree{left = L, key = K2, value = V2, right = R2};
+delete(X, #tree{key = K, value = V, left = L, right = R}) when X < K ->
+  #tree{key = K, value = V, left = delete(X, L), right = R};
+delete(X, #tree{key = K, value = V, left = L, right = R}) when X > K ->
+  #tree{key = K, value = V, left = L, right = delete(X, R)}.
+
+%% @doc delete entry with smallest key from BST, returns deleted entry and new tree
+delete_min(#tree{key = K, value = V, left = empty, right = empty}) -> {{K,V}, empty};
+delete_min(#tree{key = K, value = V, left = empty, right = R}) -> {{K,V}, R};
+delete_min(#tree{key = K, value = V, left = L, right = R}) ->
+  {{K2, V2}, L2} = delete_min(L),
+  {{K2, V2}, #tree{key = K, value = V, left = L2, right = R}}.
 
 %% @doc map values of BST
 -spec mapVal(fun((A) -> B), bst(K,A)) -> bst(K,B).

--- a/src/bst.erl
+++ b/src/bst.erl
@@ -11,7 +11,9 @@
     all/2, any/2,
     mapVal/2,
     merge/2,
-    elements/1, from_list/1, 
+    elements/1,
+    inorder_traversal/1, preorder_traversal/1, postorder_traversal/1,
+    from_list/1,
     is_bst/1, equal/2]).
 -export_type([emptyBst/0, bstNode/2, bst/2, predicate/2]).
 -record(tree, {left, key, value, right}).
@@ -96,11 +98,31 @@ is_bst(#tree{left = L, key = K, right = R}) ->
 
 %% @doc converts BST to association list - in order traversals
 -spec elements(bst(K,V)) -> [{K,V}].
-elements(T) -> elements(T, []).
+elements(T) -> inorder_traversal(T, []).
 
-elements(empty, Acc) -> Acc;
-elements(#tree{left = L, key = K, value = V, right = R}, Acc) ->
-    elements(L, [{K,V} | elements(R, Acc)]).
+%% @doc converts BST to association list using in-order traversals
+-spec inorder_traversal(bst(K,V)) -> [{K,V}].
+inorder_traversal(T) -> inorder_traversal(T, []).
+
+inorder_traversal(empty, Acc) -> Acc;
+inorder_traversal(#tree{left = L, key = K, value = V, right = R}, Acc) ->
+  inorder_traversal(L, [{K,V}|inorder_traversal(R, Acc)]).
+
+%% @doc converts BST to association list using pre-order traversals
+-spec preorder_traversal(bst(K,V)) -> [{K,V}].
+preorder_traversal(T) -> preorder_traversal(T, []).
+
+preorder_traversal(empty, Acc) -> Acc;
+preorder_traversal(#tree{left = L, key = K, value = V, right = R}, Acc) ->
+  [{K,V}|preorder_traversal(L, preorder_traversal(R,Acc))].
+
+%% @doc converts BST to association list using post-order traversals
+-spec postorder_traversal(bst(K,V)) -> [{K,V}].
+postorder_traversal(T) -> postorder_traversal(T, []).
+
+postorder_traversal(empty, Acc) -> Acc;
+postorder_traversal(#tree{left = L, key = K, value = V, right = R}, Acc) ->
+  postorder_traversal(L, postorder_traversal(R, [{K,V}|Acc])).
 
 %% @doc converts list to BST
 -spec from_list([{K,V}]) -> bst(K,V).

--- a/test/bst_tests.erl
+++ b/test/bst_tests.erl
@@ -5,18 +5,18 @@
 
 tree_test_() ->
   BST =
-    unsafe_tree(
-      bst:new(2, "two"),
-      4, "four",
-      bst:new(5, "five")),
+    new(
+      new(2),
+      4,
+      new(5)),
   %             5
   %     2             7
   %  1     3        6   8
   %          4             9
-  BSTBig = unsafe_tree(
-      unsafe_tree(bst:new(1, "1"), 2, "2", unsafe_tree(empty, 3, "3", bst:new(4, "4"))),
-    5, "5",
-      unsafe_tree(bst:new(6, "6"), 7, "7", unsafe_tree(empty, 8, "8", bst:new(9, "9")))),
+  BSTBig = new(
+      new(new(1), 2, new(empty, 3, new(4))),
+      5,
+      new(new(6), 7, new(empty, 8, new(9)))),
     [test_put(BST),
       test_get_key_in_left_subtree(BST),
       test_get_key_in_right_subtree(BST),
@@ -28,14 +28,19 @@ tree_test_() ->
       test_inorder_traversal(BSTBig),
       test_preorder_traversal(BSTBig),
       test_preorder_traversal2(BSTBig),
-      test_postorder_traversal(BSTBig)].
+      test_postorder_traversal(BSTBig),
+      test_delete_left(),
+      test_delete_right(),
+      test_delete_parent_empty_children(),
+      test_delete_nested(),
+      test_delete_not_existing_key()].
 
 test_put(BST) ->
-  ?_assertEqual(bst:put(5, "five", (bst:put(2,"two",(bst:new(4,"four"))))), BST).
+  ?_assertEqual(bst:put(5, "5", (bst:put(2,"2",(bst:new(4,"4"))))), BST).
 test_get_key_in_right_subtree(BST) ->
-  ?_assertEqual("five", bst:get("", 5, BST)).
+  ?_assertEqual("5", bst:get("", 5, BST)).
 test_get_key_in_left_subtree(BST) ->
-  ?_assertEqual("two", bst:get("", 2, BST)).
+  ?_assertEqual("2", bst:get("", 2, BST)).
 test_get_missing_key(BST) ->
   ?_assertEqual("", bst:get("", 3, BST)).
 test_is_key_missing_key(BST) ->
@@ -44,10 +49,10 @@ test_is_bst_holds_for_valid_bst(BST) ->
   ?_assertEqual(true, bst:is_bst(BST)).
 test_is_bst_detect_invalid_bst() ->
   ?_assertEqual(false,
-    bst:is_bst(unsafe_tree(
-      bst:new(5, "five"),
-      4, "four",
-      bst:new(2, "two")
+    bst:is_bst(new(
+      new(5),
+      4,
+      new(2)
     ))
 ).
 test_elements_create_assoc_list(BST) -> ?_assertEqual(
@@ -75,4 +80,40 @@ test_postorder_traversal(BST) -> ?_assertEqual(
   bst:postorder_traversal(BST)
 ).
 
-unsafe_tree(L,K,V,R) -> {tree, L, K, V, R}.
+test_delete_left() -> ?_assertEqual(
+                         new(4),
+  bst:delete(5, new(new(4), 5, bst:empty()))
+).
+
+test_delete_right() -> ?_assertEqual(
+                                         new(6),
+  bst:delete(5, new(bst:empty(), 5, new(6)))
+).
+
+test_delete_parent_empty_children() -> ?_assertEqual(
+  new(new(4), 6, bst:empty()),
+  bst:delete(5, new(new(4), 5, new(6)))
+).
+
+test_delete_nested() ->
+  ?_assertEqual(
+              new(new(new(2), 4, bst:empty()), 5, new(bst:empty(), 6, new(7))),
+  bst:delete(3, new(new(new(2), 3, new(4)), 5, new(bst:empty(), 6,  new(7))))
+).
+
+% Keep this failing test, I want custom assert - nice visualisations, output in the format I use co create tests - use new/2 new/4 etc
+% test_delete_node_with_non_emty_children() ->
+%   ?_assertEqual(
+%   new(new(2), 3, new(bst:empty(), 6, new(7))),
+%   bst:delete(new(new(new(2), 3, new(4)), 5, new(bst:empty(), 6,  new(7))), 5)
+% ).
+
+test_delete_not_existing_key() ->
+  T = new(new(new(2), 3, new(4)), 5, new(bst:empty(), 6,  new(7))),
+  ?_assertEqual(T, bst:delete(1, T)
+).
+
+test_value(K) -> integer_to_list(K).
+new(K) -> bst:new(K, test_value(K)).
+new(L,K,R) -> new(L,K,test_value(K), R).
+new(L,K,V,R) -> {tree, L, K, V, R}.

--- a/test/bst_tests.erl
+++ b/test/bst_tests.erl
@@ -9,6 +9,14 @@ tree_test_() ->
       bst:new(2, "two"),
       4, "four",
       bst:new(5, "five")),
+  %             5
+  %     2             7
+  %  1     3        6   8
+  %          4             9
+  BSTBig = unsafe_tree(
+      unsafe_tree(bst:new(1, "1"), 2, "2", unsafe_tree(empty, 3, "3", bst:new(4, "4"))),
+    5, "5",
+      unsafe_tree(bst:new(6, "6"), 7, "7", unsafe_tree(empty, 8, "8", bst:new(9, "9")))),
     [test_put(BST),
       test_get_key_in_left_subtree(BST),
       test_get_key_in_right_subtree(BST),
@@ -16,7 +24,11 @@ tree_test_() ->
       test_is_key_missing_key(BST),
       test_is_bst_holds_for_valid_bst(BST),
       test_is_bst_detect_invalid_bst(),
-      test_elements_create_assoc_list(BST)].
+      test_elements_create_assoc_list(BSTBig),
+      test_inorder_traversal(BSTBig),
+      test_preorder_traversal(BSTBig),
+      test_preorder_traversal2(BSTBig),
+      test_postorder_traversal(BSTBig)].
 
 test_put(BST) ->
   ?_assertEqual(bst:put(5, "five", (bst:put(2,"two",(bst:new(4,"four"))))), BST).
@@ -38,7 +50,29 @@ test_is_bst_detect_invalid_bst() ->
       bst:new(2, "two")
     ))
 ).
-test_elements_create_assoc_list(BST) ->
-  ?_assertEqual([{2, "two"}, {4, "four"}, {5, "five"}], bst:elements(BST)).
+test_elements_create_assoc_list(BST) -> ?_assertEqual(
+  [{1,"1"}, {2,"2"}, {3,"3"}, {4,"4"}, {5,"5"}, {6,"6"}, {7,"7"}, {8,"8"}, {9,"9"}],
+  bst:elements(BST)
+).
+
+test_inorder_traversal(BST) -> ?_assertEqual(
+  [{1,"1"}, {2,"2"}, {3,"3"}, {4,"4"}, {5,"5"}, {6,"6"}, {7,"7"}, {8,"8"}, {9,"9"}],
+  bst:inorder_traversal(BST)
+).
+
+test_preorder_traversal(BST) -> ?_assertEqual(
+  [{5,"5"}, {2,"2"}, {1,"1"}, {3,"3"}, {4,"4"}, {7,"7"}, {6,"6"}, {8,"8"}, {9,"9"}],
+  bst:preorder_traversal(BST)
+).
+
+test_preorder_traversal2(BST) -> ?_assertEqual(
+  [{5,"5"}, {2,"2"}, {1,"1"}, {3,"3"}, {4,"4"}, {7,"7"}, {6,"6"}, {8,"8"}, {9,"9"}],
+  bst:preorder_traversal(BST)
+).
+
+test_postorder_traversal(BST) -> ?_assertEqual(
+  [{1,"1"}, {4,"4"}, {3,"3"}, {2,"2"}, {6,"6"}, {9,"9"}, {8,"8"}, {7,"7"}, {5,"5"}],
+  bst:postorder_traversal(BST)
+).
 
 unsafe_tree(L,K,V,R) -> {tree, L, K, V, R}.


### PR DESCRIPTION
Binary Search Tree:
* pre-order traversal
* post-order traversal
* in-order traversal (extracted from elements)
* delete that swap in-order successor rather than deleting recursively